### PR TITLE
Add base composition and strand bias metrics

### DIFF
--- a/mqforensics/README.md
+++ b/mqforensics/README.md
@@ -11,6 +11,7 @@ Fast C/htslib tool to extract per-site (within a BED) and per-interval mapping s
 - Optional histograms (`--emit-hist`) allow divergences (KS, Wasserstein-1, Jensen–Shannon) and histogram-based medians to be computed later in summarize.
 - Optional flanking-region context (`--flank N`, `--ref-only`) computes per-site windowed means of coverage and clip-fraction in the surrounding region, optionally restricted to ref-matching bases only.
 - Summarizer reduces hundreds of per-sample TSVs (concatenated/sorted) into pooled per-site summary statistics across samples.
+- Phase 2 adds per-strand base counts, base-composition entropy, GC fractions, and strand-bias metrics at every site.
 
 # Build
 
@@ -95,6 +96,10 @@ effmq_mean  effmq_median  effmq_sd
 subQ_mean  subQ_median  subQ_sd
 clipQ_mean  clipQ_median  clipQ_sd
 [flank_cov_mean  flank_clipfrac_mean]   # if --flank enabled
+nA_fwd  nC_fwd  nG_fwd  nT_fwd  nN_fwd  nA_rev  nC_rev  nG_rev  nT_rev  nN_rev  depth_fwd  depth_rev
+entropy_pooled  alph_eff_pooled  entropy_fwd  alph_eff_fwd  entropy_rev  alph_eff_rev
+gc_frac_pooled  gc_frac_fwd  gc_frac_rev
+strand_bias_z
 ```
 
 **Per-site (suffstats mode)**
@@ -110,6 +115,7 @@ n_clipfrac sum_clipfrac sumsq_clipfrac
 n_capped sum_delta sumsq_delta
 [n_flank_cov sum_flank_cov sumsq_flank_cov
  n_flank_cf  sum_flank_cf  sumsq_flank_cf]   # if --flank enabled
+nA_fwd nC_fwd nG_fwd nT_fwd nN_fwd nA_rev nC_rev nG_rev nT_rev nN_rev
 [hists …]   # if --emit-hist
 ```
 
@@ -126,6 +132,7 @@ From suffstats input, `summarize` produces:
 - pooled mean & SD for: MQ, capMQ, effMQ, SubQ, ClipQ, clipfrac
 - capping load: frac_capped, delta mean/sd
 - flanking context pooled stats: flank_cov_mean/sd, flank_cf_mean/sd (if present)
+- per-strand base composition: entropy (bits and effective alphabet), GC fractions (pooled/fwd/rev), strand-bias z-score
 - optional divergences & histogram-based medians if `--emit-hist`
 
 

--- a/mqforensics/include/common.h
+++ b/mqforensics/include/common.h
@@ -40,6 +40,10 @@ typedef struct {
     long long    n_flank_cf;
     long double  sum_flank_cf,  sumsq_flank_cf;
 
+    // Phase 2: per-strand base counts (aligned bases only; N tracked)
+    long long nA_fwd, nC_fwd, nG_fwd, nT_fwd, nN_fwd;
+    long long nA_rev, nC_rev, nG_rev, nT_rev, nN_rev;
+
     // hist bins (per-BAM site; filled only when --emit-hist)
     int hist_mq[7];        // MQ [0..60] in bins of 10
     int hist_eff[7];       // effMQ [0..60] in bins of 10
@@ -81,6 +85,10 @@ typedef struct {
     long long    n_flank_cf;
     long double  sum_flank_cf,  sumsq_flank_cf;
 
+    // Phase 2 pooled counts
+    long long nA_fwd, nC_fwd, nG_fwd, nT_fwd, nN_fwd;
+    long long nA_rev, nC_rev, nG_rev, nT_rev, nN_rev;
+
     // pooled hists
     long long hist_mq[7], hist_eff[7], hist_clipfrac[10];
     bool have_hist;
@@ -93,6 +101,10 @@ double dmean(const vecd *x);
 double dmedian(vecd *x);
 double dsd(const vecd *x);
 double median_from_hist_uniform_bins(const long long *h, int nbins, double bin0_left, double bin_width);
+
+double entropy_from_counts(long long nA, long long nC, long long nG, long long nT);
+double gcfrac_from_counts(long long nA, long long nC, long long nG, long long nT);
+double strand_bias_z(long long depth_fwd, long long depth_rev);
 
 // hist.c
 void hist_accum_mq(int *hist7, int mq0_60);

--- a/mqforensics/src/stats.c
+++ b/mqforensics/src/stats.c
@@ -50,3 +50,30 @@ double median_from_hist_uniform_bins(const long long *h, int nbins, double bin0_
     }
     return bin0_left + (nbins-0.5)*bin_width;
 }
+
+// Phase 2 helpers
+double entropy_from_counts(long long nA, long long nC, long long nG, long long nT){
+    long long n = nA + nC + nG + nT;
+    if (n <= 0) return NAN;
+    double H = 0.0;
+    long long v[4] = {nA, nC, nG, nT};
+    for (int i=0;i<4;i++){
+        if (v[i] > 0){
+            double p = (double)v[i] / (double)n;
+            H -= p * (log(p)/log(2.0));
+        }
+    }
+    return H;
+}
+
+double gcfrac_from_counts(long long nA, long long nC, long long nG, long long nT){
+    long long denom = nA + nC + nG + nT;
+    if (denom <= 0) return NAN;
+    return (double)(nC + nG) / (double)denom;
+}
+
+double strand_bias_z(long long depth_fwd, long long depth_rev){
+    long long tot = depth_fwd + depth_rev;
+    if (tot <= 0) return NAN;
+    return (double)(depth_fwd - depth_rev) / sqrt((double)tot);
+}


### PR DESCRIPTION
## Summary
- track per-strand base counts and forward/reverse depths
- report pileup entropy, GC fractions and strand-bias z in analyze and summarize
- expose helpers and document new columns

## Testing
- `make`
- `../mqforensics/mq_forensics analyze -b read.bam -r region.bed -C 50 -d 0 -o direct.tsv -O iv.tsv`
- `../mqforensics/mq_forensics analyze --emit-suffstats -b read.bam -r region.bed -C 50 -d 0 -o suff.tsv -O iv.tsv`
- `../mqforensics/mq_forensics summarize -i suff.tsv -o summary.tsv`


------
https://chatgpt.com/codex/tasks/task_e_68bae0b9984083328a253f507f42673a